### PR TITLE
Fix intro/recap text formatting in CLI and web demo

### DIFF
--- a/src/demo/parser.ts
+++ b/src/demo/parser.ts
@@ -127,22 +127,25 @@ function extractCommentary(bq: Blockquote): string | null {
 
 /**
  * Serialize list and paragraph nodes into plain description text.
+ * Paragraphs and lists are separated by double newlines so renderers
+ * can distinguish paragraph breaks from line breaks within a list.
  */
 function nodesToDescription(nodes: Content[]): string {
-  const parts: string[] = [];
+  const blocks: string[] = [];
   for (const node of nodes) {
     if (node.type === "paragraph") {
-      parts.push(nodeToText(node));
+      blocks.push(nodeToText(node));
     } else if (node.type === "list") {
       const list = node as List;
-      list.children.forEach((item, i) => {
+      const items = list.children.map((item, i) => {
         const text = nodeToText(item).trim();
         const prefix = list.ordered ? `${(list.start ?? 1) + i}. ` : "- ";
-        parts.push(prefix + text);
+        return prefix + text;
       });
+      blocks.push(items.join("\n"));
     }
   }
-  return parts.join("\n").trim();
+  return blocks.join("\n\n").trim();
 }
 
 // ── Core parser ────────────────────────────────────────────────────

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -203,11 +203,24 @@
         margin-bottom: 1rem;
       }
 
-      .wizard-description pre {
-        white-space: pre-wrap;
+      .wizard-description p {
         font-size: 0.85rem;
         line-height: 1.6;
         color: var(--text);
+        margin: 0 0 0.75rem 0;
+      }
+
+      .wizard-description ol,
+      .wizard-description ul {
+        font-size: 0.85rem;
+        line-height: 1.6;
+        color: var(--text);
+        margin: 0 0 0.75rem 0;
+        padding-left: 1.5rem;
+      }
+
+      .wizard-description li {
+        margin-bottom: 0.25rem;
       }
 
       .wizard-commands {

--- a/web/src/wizard.ts
+++ b/web/src/wizard.ts
@@ -158,9 +158,41 @@ export function createWizard(
     if (step.description) {
       const desc = document.createElement("div");
       desc.className = "wizard-description";
-      const pre = document.createElement("pre");
-      pre.textContent = step.description;
-      desc.appendChild(pre);
+
+      // Split on double newlines to get logical blocks (paragraphs / lists)
+      const blocks = step.description.split(/\n\n+/);
+      for (const block of blocks) {
+        const trimmed = block.trim();
+        if (!trimmed) continue;
+
+        // Detect ordered or unordered list blocks
+        const lines = trimmed.split("\n");
+        const isOrderedList = lines.every((l) => /^\d+\.\s/.test(l));
+        const isUnorderedList = lines.every((l) => /^[-*]\s/.test(l));
+
+        if (isOrderedList) {
+          const ol = document.createElement("ol");
+          for (const line of lines) {
+            const li = document.createElement("li");
+            li.textContent = line.replace(/^\d+\.\s/, "");
+            ol.appendChild(li);
+          }
+          desc.appendChild(ol);
+        } else if (isUnorderedList) {
+          const ul = document.createElement("ul");
+          for (const line of lines) {
+            const li = document.createElement("li");
+            li.textContent = line.replace(/^[-*]\s/, "");
+            ul.appendChild(li);
+          }
+          desc.appendChild(ul);
+        } else {
+          const p = document.createElement("p");
+          p.textContent = trimmed;
+          desc.appendChild(p);
+        }
+      }
+
       section.appendChild(desc);
     }
 


### PR DESCRIPTION
## Summary

- **Parser**: `nodesToDescription` now separates paragraphs and list blocks with `\n\n` instead of `\n`, preserving paragraph structure in the `description` field
- **Web wizard**: Replaced single `<pre>` tag with structured HTML — paragraphs render as `<p>`, ordered lists as `<ol>/<li>`, unordered lists as `<ul>/<li>`
- **Web CSS**: Replaced `.wizard-description pre` styles with proper typography for `p`, `ol`, `ul`, and `li` elements

The CLI runner needed no changes — it already splits on `\n`, and the double newlines naturally produce visible paragraph breaks.

## Problem

The intro and recap steps displayed their text as a wall of text with no visual separation between paragraphs and lists, while the act steps (which use structured problem/solution/commands/commentary fields) looked great.

Root cause: the parser's `nodesToDescription` joined all blocks with single `\n`, and the web wizard dumped it into a `<pre>` tag.

## Files Changed

| File | Change |
|------|--------|
| `src/demo/parser.ts` | `nodesToDescription` uses `\n\n` between blocks |
| `web/src/wizard.ts` | Structured HTML rendering for description blocks |
| `web/src/index.html` | CSS for `p`, `ol`, `ul`, `li` in `.wizard-description` |

## Testing

- 98 root tests pass
- 35 web tests pass
- 5 Playwright E2E tests pass
- Build clean

Closes TF-0MLXJ6JKK1L2QC10