### PR TITLE
TF-0MLYE19WF0CCG3C4: Add dev:web instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Or generate a sound directly:
 npx tsx src/cli.ts generate --recipe ui-scifi-confirm --seed 42
 ```
 
+Run the web demo (starts the backend server and Vite dev server):
+
+```
+npm run dev:web
+```
+
 The `docs/prd/` directory contains detailed product requirements documents for planned modules beyond the MVP.
 
 ## Planned Tech Stack


### PR DESCRIPTION
## Summary

- Add `npm run dev:web` instructions to the README Status section so developers can discover the web demo launch command without digging through package.json

Related: The time-dependent phrasing fix in `demos/recipe-variety.md` ("ToneForge now ships" -> "This ToneForge demo ships") will be included in PR #4 since that file only exists on the recipe-variety branch.

Work item: TF-0MLYE19WF0CCG3C4