### PR TITLE
TF-0MLYNPWKT1ISEFXX: Remove startup banner and add version subcommand

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -118,6 +118,14 @@ describe("CLI", () => {
   });
 
   describe("generate command", () => {
+    it("does not print startup banner to stdout", async () => {
+      const { code, stdout } = await captureOutput(
+        () => main(argv("generate", "--recipe", "ui-scifi-confirm", "--seed", "42")),
+      );
+      expect(code).toBe(0);
+      expect(stdout).not.toMatch(/^ToneForge v\d+\.\d+\.\d+$/m);
+    });
+
     it("renders and plays with explicit seed (exit 0)", async () => {
       const { code, stdout } = await captureOutput(
         () => main(argv("generate", "--recipe", "ui-scifi-confirm", "--seed", "42")),
@@ -396,6 +404,33 @@ describe("CLI", () => {
       );
       expect(code).toBe(0);
       expect(stdout).toContain("play");
+    });
+  });
+
+  describe("version", () => {
+    it("prints version with 'version' command", async () => {
+      const { code, stdout } = await captureOutput(() => main(argv("version")));
+      expect(code).toBe(0);
+      expect(stdout).toMatch(/^ToneForge v\d+\.\d+\.\d+$/);
+    });
+
+    it("prints version with --version flag", async () => {
+      const { code, stdout } = await captureOutput(() => main(argv("--version")));
+      expect(code).toBe(0);
+      expect(stdout).toMatch(/^ToneForge v\d+\.\d+\.\d+$/);
+    });
+
+    it("prints version with -V flag", async () => {
+      const { code, stdout } = await captureOutput(() => main(argv("-V")));
+      expect(code).toBe(0);
+      expect(stdout).toMatch(/^ToneForge v\d+\.\d+\.\d+$/);
+    });
+
+    it("version appears in top-level help text", async () => {
+      const { code, stdout } = await captureOutput(() => main(argv("--help")));
+      expect(code).toBe(0);
+      expect(stdout).toContain("version");
+      expect(stdout).toContain("--version");
     });
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,12 +4,15 @@
  *
  * Entry point for the `toneforge` command-line tool.
  * Supports the `generate` command to render, play, and export procedural sounds,
- * and the `play` command to play WAV files from disk.
+ * the `play` command to play WAV files from disk, and the `version` command to
+ * print the current ToneForge version.
  *
  * Usage:
  *   toneforge generate --recipe <name> [--seed <number>] [--output <path.wav>]
  *   toneforge generate --recipe <name> --seed-range <start>:<end> --output <directory/>
  *   toneforge play <file.wav>
+ *   toneforge version
+ *   toneforge --version
  *   toneforge --help
  *
  * Reference: docs/prd/CLI_PRD.md Section 4.1, 5.1
@@ -41,6 +44,8 @@ function parseArgs(argv: string[]): {
     const arg = args[i]!;
     if (arg === "--help" || arg === "-h") {
       flags["help"] = true;
+    } else if (arg === "--version" || arg === "-V") {
+      flags["version"] = true;
     } else if (arg.startsWith("--")) {
       const key = arg.slice(2);
       const next = args[i + 1];
@@ -71,9 +76,11 @@ Commands:
   generate    Render and export procedural sounds
   play        Play a WAV file through the system audio player
   list        List available resources (e.g. recipes)
+  version     Print the ToneForge version
 
 Options:
-  --help, -h  Show this help message
+  --help, -h     Show this help message
+  --version, -V  Print the ToneForge version
 
 Run 'toneforge <command> --help' for command-specific help.`);
 }
@@ -143,6 +150,12 @@ Examples:
 /** Main CLI entry point. Exported for testability. */
 export async function main(argv: string[] = process.argv): Promise<number> {
   const { command, subcommand, flags } = parseArgs(argv);
+
+  // --version flag or `version` command
+  if (flags["version"] || command === "version") {
+    console.log(`ToneForge v${VERSION}`);
+    return 0;
+  }
 
   // Top-level help
   if (flags["help"] || command === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,3 @@
  */
 
 export const VERSION = "0.1.0";
-
-console.log(`ToneForge v${VERSION}`);


### PR DESCRIPTION
## Summary

- **Removed** the stray `ToneForge v0.1.0` startup banner that printed on every CLI invocation (`console.log` in `src/index.ts`)
- **Added** `tf version` command, `tf --version` flag, and `tf -V` shorthand that print `ToneForge v<version>` and exit with code 0
- **Updated** `tf --help` to list `version` as an available command and `--version, -V` as a global option

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Removed `console.log` banner (line 10); `VERSION` export preserved |
| `src/cli.ts` | Added `--version`/`-V` flag parsing, `version` command handler, updated help text and JSDoc |
| `src/cli.test.ts` | Added 5 new tests: version command, --version flag, -V flag, help listing, no-banner verification |

## Acceptance Criteria

- [x] `tf generate --recipe ui-scifi-confirm --seed 42` does NOT print `ToneForge v0.1.0` to stdout
- [x] `tf version` prints exactly `ToneForge v<version>` and exits with code 0
- [x] `tf --version` also prints the version and exits with code 0
- [x] `tf --help` lists `version` as an available command
- [x] All existing tests pass (253 total, including 5 new)
- [x] No other module behaviour changed

## Testing

All 253 tests pass. TypeScript compiles cleanly with `tsc --noEmit`.

Work item: TF-0MLYNPWKT1ISEFXX