### PR TITLE
TF-0MLYQ43UW12EVR3X: Replace static Vite proxy with dynamic backend proxy plugin

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,13 +1,21 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import { resolve } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
+import { request as httpRequest } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Socket } from "node:net";
 
 const projectRoot = resolve(__dirname, "..");
 const PORT_FILE = resolve(__dirname, ".port");
+const DEFAULT_BACKEND_PORT = 3000;
 
 /**
- * Discover the backend port for the WebSocket proxy.
+ * Discover the backend port dynamically on every call.
  * Priority: .port file > BACKEND_PORT env var > default 3000.
+ *
+ * This is called per-request so that when the backend retries onto a
+ * non-default port and writes `.port`, subsequent proxy requests pick
+ * up the correct value — even though Vite started before the backend.
  */
 function getBackendPort(): number {
   // 1. Try the .port coordination file (written by the backend after listen)
@@ -28,10 +36,123 @@ function getBackendPort(): number {
   }
 
   // 3. Default
-  return 3000;
+  return DEFAULT_BACKEND_PORT;
 }
 
-const BACKEND_PORT = getBackendPort();
+/**
+ * Vite plugin that proxies /ws/* requests to the backend with
+ * dynamic port resolution on every connection.
+ *
+ * This replaces the static `server.proxy` config so that the proxy
+ * works even when the backend starts on a non-default port after
+ * Vite has already loaded its config.
+ */
+function dynamicBackendProxy(): Plugin {
+  return {
+    name: "toneforge-dynamic-backend-proxy",
+    configureServer(server) {
+      // ── WebSocket upgrade proxy ────────────────────────────
+      // Vite's httpServer is available once the server is set up.
+      // We listen for 'upgrade' events and forward /ws/* to the backend.
+      server.httpServer?.on(
+        "upgrade",
+        (req: IncomingMessage, socket: Socket, head: Buffer) => {
+          const url = req.url ?? "/";
+          if (!url.startsWith("/ws")) return; // let Vite HMR handle its own upgrades
+
+          const backendPort = getBackendPort();
+
+          const proxyReq = httpRequest({
+            hostname: "localhost",
+            port: backendPort,
+            path: url,
+            method: req.method,
+            headers: req.headers,
+          });
+
+          proxyReq.on("upgrade", (_proxyRes, proxySocket, proxyHead) => {
+            socket.write(
+              "HTTP/1.1 101 Switching Protocols\r\n" +
+                "Upgrade: websocket\r\n" +
+                "Connection: Upgrade\r\n" +
+                // Forward any additional headers from the backend response
+                Object.entries(_proxyRes.headers)
+                  .filter(
+                    ([k]) =>
+                      !["upgrade", "connection"].includes(k.toLowerCase()),
+                  )
+                  .map(([k, v]) => `${k}: ${v}`)
+                  .join("\r\n") +
+                "\r\n\r\n",
+            );
+
+            if (proxyHead && proxyHead.length > 0) {
+              socket.write(proxyHead);
+            }
+
+            // Bi-directional pipe
+            proxySocket.pipe(socket);
+            socket.pipe(proxySocket);
+
+            proxySocket.on("error", () => socket.destroy());
+            socket.on("error", () => proxySocket.destroy());
+          });
+
+          proxyReq.on("error", (err) => {
+            console.error(
+              `[toneforge-proxy] WebSocket proxy error to port ${backendPort}:`,
+              err.message,
+            );
+            socket.destroy();
+          });
+
+          // Forward the upgrade head data and end the request
+          proxyReq.end(head);
+        },
+      );
+
+      // ── HTTP middleware proxy for /ws/* (non-upgrade) ───────
+      // This handles any regular HTTP requests to /ws/* paths,
+      // e.g. health checks or HTTP-based fallbacks.
+      server.middlewares.use((req: IncomingMessage, res: ServerResponse, next: () => void) => {
+        const url = req.url ?? "/";
+        if (!url.startsWith("/ws")) {
+          next();
+          return;
+        }
+
+        const backendPort = getBackendPort();
+
+        const proxyReq = httpRequest(
+          {
+            hostname: "localhost",
+            port: backendPort,
+            path: url,
+            method: req.method,
+            headers: req.headers,
+          },
+          (proxyRes) => {
+            res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+            proxyRes.pipe(res);
+          },
+        );
+
+        proxyReq.on("error", (err) => {
+          console.error(
+            `[toneforge-proxy] HTTP proxy error to port ${backendPort}:`,
+            err.message,
+          );
+          if (!res.headersSent) {
+            res.writeHead(502, { "Content-Type": "text/plain" });
+            res.end("Bad Gateway: backend not available");
+          }
+        });
+
+        req.pipe(proxyReq);
+      });
+    },
+  };
+}
 
 export default defineConfig({
   root: "src",
@@ -47,14 +168,10 @@ export default defineConfig({
       "@demos": resolve(projectRoot, "demos"),
     },
   },
+  plugins: [dynamicBackendProxy()],
   server: {
     port: parseInt(process.env.VITE_PORT || "5173", 10),
-    proxy: {
-      "/ws": {
-        target: `http://localhost:${BACKEND_PORT}`,
-        ws: true,
-        changeOrigin: true,
-      },
-    },
+    // Proxy is now handled dynamically by the toneforge-dynamic-backend-proxy
+    // plugin above — no static proxy config needed.
   },
 });


### PR DESCRIPTION
## Summary

- Introduces a custom Vite plugin (`toneforge-dynamic-backend-proxy`) that replaces the static `server.proxy` config with per-request dynamic port resolution
- Resolves the race condition where the Vite proxy locks onto port 3000 before the backend has written its actual port to `.port`
- Adds HTTP middleware proxying for `/ws/*` paths (previously only WebSocket upgrades were proxied)

## Background

The previous static proxy config evaluated `getBackendPort()` once at module load time and passed it to Vite's `server.proxy`. When `concurrently` launches both the backend and Vite simultaneously, the backend may not have written its `.port` file yet — or may retry onto a non-default port (e.g., 3001 due to EADDRINUSE). Either way, Vite's proxy was already frozen on `localhost:3000`, silently breaking WebSocket terminal connections.

## What changed

### New: `dynamicBackendProxy()` Vite plugin (`web/vite.config.ts`)

Uses Vite's `configureServer` hook to register two proxy layers:

1. **WebSocket upgrade handler** — listens for `upgrade` events on Vite's HTTP server, intercepts `/ws/*` paths, reads `.port` on every connection attempt, and proxies the upgrade using Node's `http.request`. Non-`/ws` upgrades (e.g., Vite HMR) are left untouched.

2. **HTTP middleware** — handles regular (non-upgrade) requests to `/ws/*` paths with the same dynamic port lookup. Returns 502 Bad Gateway with a clear error message when the backend is unavailable.

### Removed: static `server.proxy` config

The previous `server.proxy["/ws"]` block with a fixed `target` is removed. All proxying is now handled by the plugin.

### Changed: `getBackendPort()` is now called per-request

Previously called once at module scope (`const BACKEND_PORT = getBackendPort()`), now called on every proxy request so it always reflects the current `.port` file contents. The fallback chain is unchanged: `.port` file > `BACKEND_PORT` env var > default 3000.

## Files Changed

- `web/vite.config.ts` — +128/-11 lines

## Testing

- All 253 root tests pass
- All 106 web tests pass (including 6 port-retry tests)
- Typechecks pass for both root and web projects
- Both builds succeed

## Work Item

Resolves TF-0MLYQ43UW12EVR3X (discovered-from: TF-0MLYI74BU1I33ZJN)