### PR TITLE
TF-0MM1PLGKW1JCESQF: Add 5th audition command to Library demo Act 1

### DIFF
--- a/demos/library.md
+++ b/demos/library.md
@@ -85,13 +85,16 @@ toneforge generate --recipe weapon-laser-zap --seed 0
 toneforge generate --recipe weapon-laser-zap --seed 4
 toneforge generate --recipe weapon-laser-zap --seed 30
 toneforge generate --recipe weapon-laser-zap --seed 2
+toneforge generate --recipe weapon-laser-zap --seed 9
 ```
 
 Seed 0 (cluster 0) is the sharpest and brightest. Seeds 4 and 30
 (cluster 1) are heavy and direct -- high energy with a dark timbre, and
 nearly identical metrics. Seed 2 (also cluster 1) pushes harder but is
-shorter. Pick seed 0 as the lead and two cluster-1 neighbours to build
-a palette where the alternatives are close enough to swap freely.
+shorter. Seed 9 rounds out the audition -- similar to 4 and 30 but
+slightly softer. Pick seed 0 as the lead and two cluster-1 neighbours
+(4 and 30) to build a palette where the alternatives are close enough
+to swap freely.
 
 Use `--category` on promote to organize entries from the start.
 Seed 0 is the lead shot -- file it under `weapon`. Seeds 4 and 30 are


### PR DESCRIPTION
## Summary

The Library demo Act 1 acceptance criteria require 5 play commands showing candidates from clusters 0 and 1, but only 4 audition commands were present. This PR adds the missing 5th audition command.

## Changes

- **demos/library.md**: Added `toneforge generate --recipe weapon-laser-zap --seed 9` as the 5th audition command in Act 1. Seed 9 is from cluster 1 (rms=0.927, spectral-centroid=0.058). Updated the narrative to describe seed 9 as similar to seeds 4 and 30 but slightly softer, reinforcing the palette selection reasoning.

## Work Item

- TF-0MM1PLGKW1JCESQF: Revise Library demo Act 1: single sweep with cluster-based audition and promotion

## Acceptance Criteria Verification

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Act 1 uses a single weapon-laser-zap sweep (50 seeds, 4 clusters) | PASS |
| 2 | 5 play commands show candidates from clusters 0 and 1 | PASS (was 4, now 5) |
| 3 | 3 promote commands pick 1 from cluster 0 and 2 from cluster 1 | PASS |
| 4 | Act 2 does not show a --json example | PASS |
| 5 | All subsequent acts reference weapon-laser-zap entries consistently | PASS |
| 6 | Demo shell script updated to match new flow | PASS |
| 7 | Demo parser tests pass | PASS (1356 root, 299 web) |
| 8 | Shell script runs end-to-end with exit 0 | PASS |

## How to Test

1. Read through Act 1 in `demos/library.md` -- confirm 5 generate commands (seeds 0, 4, 30, 2, 9)
2. Run `npx vitest run` from project root -- all 1356 tests pass (208 demo parser tests)
3. Run `bash demos/demo-07-library.sh` -- exits 0 with 3 library entries

## Review Focus

- Narrative flow: does the added sentence about seed 9 read naturally?
- The 5th seed (9) is from cluster 1 and not promoted -- this is intentional to show the audition-then-select workflow