### PR TITLE
TF-0MN50KG9O0SEHHC8: Add sequence golden fixtures and restore missing preset

### DIFF
--- a/presets/sequences/tableau_coin_collect.json
+++ b/presets/sequences/tableau_coin_collect.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0",
+  "name": "tableau_coin_collect",
+  "description": "Collect coins from the tableau market or rent collection in a high-street economy card game.",
+  "events": [
+    {
+      "time": 0,
+      "event": "card-coin-collect",
+      "seedOffset": 0,
+      "gain": 1.0
+    },
+    {
+      "time": 0.15,
+      "event": "card-chip-stack",
+      "seedOffset": 1,
+      "gain": 0.8,
+      "probability": 0.7
+    }
+  ]
+}

--- a/src/test-utils/fixtures/golden-sequences/tableau_coin_collect.golden.json
+++ b/src/test-utils/fixtures/golden-sequences/tableau_coin_collect.golden.json
@@ -1,0 +1,27 @@
+{
+  "name": "tableau_coin_collect",
+  "seed": 42,
+  "sampleRate": 44100,
+  "totalDuration": 0.15,
+  "totalDuration_ms": 150,
+  "events": [
+    {
+      "time_ms": 0,
+      "sampleOffset": 0,
+      "event": "card-coin-collect",
+      "seedOffset": 0,
+      "eventSeed": 42,
+      "gain": 1,
+      "repetition": 0
+    },
+    {
+      "time_ms": 150,
+      "sampleOffset": 6615,
+      "event": "card-chip-stack",
+      "seedOffset": 1,
+      "eventSeed": 43,
+      "gain": 0.8,
+      "repetition": 0
+    }
+  ]
+}


### PR DESCRIPTION
Restores missing preset presets/sequences/tableau_coin_collect.json (from origin/main) and adds generated golden fixtures under src/test-utils/fixtures/golden-sequences/ to satisfy the sequence golden-fixtures test. Work item: TF-0MN50KG9O0SEHHC8.